### PR TITLE
Mark repository as deprecated and archived

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,27 +1,15 @@
+# This workflow has been disabled — the repository is deprecated and archived.
 name: CD
-concurrency:
-  group: cd-${{ github.ref }}
-  cancel-in-progress: true
 on:
-  push:
-    tags:
-      - '**'
   workflow_dispatch:
+    inputs:
+      reason:
+        description: 'This repo is deprecated. Workflows are disabled.'
+        required: false
 
 jobs:
-  publish:
+  disabled:
+    if: false
     runs-on: ubuntu-latest
-    name: Publish
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
-          registry-url: 'https://registry.npmjs.org'
-      - name: Publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          npm ci
-          npm run build
-          npm publish
+      - run: echo "disabled"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,46 +1,15 @@
+# This workflow has been disabled — the repository is deprecated and archived.
 name: CI
-concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main, ci/** ]
-    types:
-      - opened
-      - synchronize
-      - reopened
   workflow_dispatch:
+    inputs:
+      reason:
+        description: 'This repo is deprecated. Workflows are disabled.'
+        required: false
 
 jobs:
-  test:
+  disabled:
+    if: false
     runs-on: ubuntu-latest
-    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4.3.0
-        with:
-          node-version: 18
-      - name: Install dependencies client
-        run: npm i --force
-      - name: Run tests
-        run: npm test
-
-  release:
-    name: Release
-    if: github.ref == 'refs/heads/main' && !startsWith( github.event.commits[0].message, 'build(deps-dev)') && !startsWith( github.event.commits[0].message, 'ci(uplift)')
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN_UPLIFT }}
-      - name: Release
-        if: github.ref == 'refs/heads/main'
-        uses: gembaadvantage/uplift-action@v2.0.2
-        with:
-          args: release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_UPLIFT }}
+      - run: echo "disabled"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> **This repository is deprecated and no longer maintained.** No further updates, bug fixes, or security patches will be provided. Please migrate to an alternative solution.
+
 # react-native-auth-guard
 
 A flexible and type-safe authentication guard for React Native apps using React Navigation and TypeScript.

--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "automerge": true,
-  "schedule": [
-    "before 4am"
-  ],
-  "automergeSchedule": [
-      "before 5am"
-  ]
+  "enabled": false
 }


### PR DESCRIPTION
## Summary
This pull request marks the repository as deprecated and archived by disabling all automated workflows and dependency management.

## Key Changes
- **CI/CD Workflows**: Disabled the CI and CD workflows by replacing all job steps with a no-op disabled job. Both workflows now only respond to manual `workflow_dispatch` triggers with an informational message.
- **Dependency Management**: Disabled Renovate bot by setting `enabled: false` in `renovate.json`, removing all automerge and scheduling configurations.
- **Documentation**: Added a deprecation warning banner to the README.md to inform users that the repository is no longer maintained and they should migrate to alternative solutions.

## Implementation Details
- The CI workflow previously ran tests on push/PR and performed automated releases; it now has a disabled job that echoes "disabled"
- The CD workflow previously published to npm on tags; it now has a disabled job that echoes "disabled"
- Both workflows retain the `workflow_dispatch` trigger to allow manual intervention if needed
- Renovate configuration was simplified to a minimal disabled state rather than being removed entirely
- The deprecation notice uses GitHub's warning callout syntax for visibility

https://claude.ai/code/session_01XGL9kjyazEwJ451Q6Kswz7